### PR TITLE
fix headers path in source file and refresh README

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,9 +1,9 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
+prefix = @prefix@
+exec_prefix = @exec_prefix@
 srcdir = @srcdir@
-libdir=@libdir@
-CFLAGS=@CFLAGS@
-CPPFLAGS=@CPPFLAGS@
+libdir ?= @libdir@
+CFLAGS = @CFLAGS@
+CPPFLAGS = @CPPFLAGS@
 
 CC=@CC@
 
@@ -16,4 +16,4 @@ clean:
 	rm -f ${srcdir}/base58.so
 
 install:
-	install -D --mode=644 ${srcdir}/base58.so ${DESTDIR}${libdir}/tarantool/base58.so
+	install -D --mode=644 ${srcdir}/base58.so ${DESTDIR}${libdir}/lua/base58.so

--- a/README
+++ b/README
@@ -1,1 +1,31 @@
 base58 encode/decode subroutines for tarantool 1.5
+
+# How to build
+### _Dependencies_
+
+Tools:
+    - autoconf
+    - make
+
+Also for building this module you should provide Lua headers files
+which you can found from original Lua sources or LuaJIT sources.
+
+Provisioning of these headers depends on distriburion package manager
+but mostly common way to get it - download from official resources e.g.
+    - Lua https://github.com/lua/lua
+    - LuaJIT from Openresty https://github.com/openresty/luajit2
+
+### _Building_
+
+```sh
+autoconf configure.am > configure
+chmod +x configure
+CPPFLAGS="${CPPFLAGS} -I/path/to/lua/headers" ./configure
+make
+```
+
+### _Installing_
+
+```sh
+make install
+```

--- a/configure.ac
+++ b/configure.ac
@@ -1,16 +1,16 @@
-AC_INIT(tarantool-base58, version-0.1)
+AC_INIT(lua-base58, version-0.1)
 AC_PREFIX_DEFAULT([/usr])
 
 AC_PROG_CC
 if test "$ac_cv_prog_cc_c89" == "no" ; then
 	AC_MSG_ERROR([c compiler not found])
 fi
-AC_CHECK_HEADERS([tarantool/lua.h])
-if test "$ac_cv_header_tarantool_lua_h" == "no" ; then
+AC_CHECK_HEADERS([lua.h])
+if test "$ac_cv_header_lua_h" == "no" ; then
 	AC_MSG_ERROR([lua.h not found])
 fi
-AC_CHECK_HEADERS([tarantool/lauxlib.h])
-if test "$ac_cv_header_tarantool_luaxlib_h" == "no" ; then
+AC_CHECK_HEADERS([lauxlib.h])
+if test "$ac_cv_header_luaxlib_h" == "no" ; then
 	AC_MSG_ERROR([luaxlib.h not found])
 fi
 srcdir="src"

--- a/extra/rpm/tarantool-base58.spec
+++ b/extra/rpm/tarantool-base58.spec
@@ -1,16 +1,15 @@
-Name:    tarantool-base58
+Name:    lua-base58
 Version: 0.01	
 Release: 1%{?dist}
-Summary: base58 encode/decode subroutines for tarantool 1.5	
+Summary: base58 encode/decode subroutines 
 
 Group:	 Development/Libraries
 License: GPLv2	
 URL:		 https://github.com/17e/tarantool-base58
 Source0: tarantool-base58.tar.bz2
 
-BuildRequires:	tarantool-dev < 1.6
+BuildRequires:	lua-devel >= 5.1
 BuildRequires:	autoconf
-Requires:	tarantool < 1.6
 
 %description
 https://github.com/17e/tarantool-base58
@@ -34,7 +33,7 @@ make install DESTDIR=%{buildroot}
 %files
 %defattr(-,root,root,-)
 %doc README
-%attr(0755, root, root) %{_libdir}/tarantool/base58.so
+%attr(0755, root, root) %{_libdir}/lua/base58.so
 
 
 %changelog

--- a/src/base58.c
+++ b/src/base58.c
@@ -6,8 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <tarantool/lua.h>
-#include <tarantool/lauxlib.h>
+#include <lua.h>
+#include <lauxlib.h>
 
 char *nb58 = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
 /****************************************************************************************************************************************************


### PR DESCRIPTION
Seems that Lua headers not supposed to distributed from tarantool sources so needs to provide an include path oh the installed header files of Lua or LuaJIT.